### PR TITLE
Update go.mod with latest oauth 0.27 for vulnerability fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/oauth2 v0.25.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect


### PR DESCRIPTION
Name: golangorg/x/oauth2
Version: 0.25.0
Path: /goto/goto

Vulnerability: CVE-2025-22868
Severity: HIGH
Source: https://github.com/advisories/GHSA-6v2p-p543-phr9
Fix version: 0.27.0
